### PR TITLE
Gather resources from json input

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -8,21 +8,21 @@ static HOURS_PER_MONTH: f32 = (365_f32 * 24_f32) / 12_f32;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "resource_type")]
-pub enum ResourceType {
+pub enum Resource {
     Vm(Vm),
     Volume(Volume),
 }
 
 pub struct Resources {
-    pub resources: Vec<ResourceType>,
+    pub resources: Vec<Resource>,
 }
 
 impl Resources {
     pub fn compute(&mut self) -> Result<(), ResourceError> {
         for resource in self.resources.iter_mut() {
             match resource {
-                ResourceType::Volume(volume) => volume.compute()?,
-                ResourceType::Vm(vm) => vm.compute()?,
+                Resource::Volume(volume) => volume.compute()?,
+                Resource::Vm(vm) => vm.compute()?,
             }
         }
         Ok(())
@@ -32,8 +32,8 @@ impl Resources {
         let mut total = 0f32;
         for resource in &self.resources {
             match resource {
-                ResourceType::Volume(volume) => total += volume.price_per_hour()?,
-                ResourceType::Vm(vm) => total += vm.price_per_hour()?,
+                Resource::Volume(volume) => total += volume.price_per_hour()?,
+                Resource::Vm(vm) => total += vm.price_per_hour()?,
             }
         }
         Ok(total)
@@ -83,7 +83,7 @@ impl fmt::Display for ResourceError {
     }
 }
 
-trait Resource {
+trait ResourceTrait {
     fn price_per_hour(&self) -> Result<f32, ResourceError>;
     fn compute(&mut self) -> Result<(), ResourceError>;
 }
@@ -114,7 +114,7 @@ pub struct Vm {
     pub price_product_per_vm_per_hour: f32,
 }
 
-impl Resource for Vm {
+impl ResourceTrait for Vm {
     fn compute(&mut self) -> Result<(), ResourceError> {
         let mut price_per_hour = 0_f32;
         price_per_hour += self.vm_vcpu as f32 * self.price_vcpu_per_hour;
@@ -152,7 +152,7 @@ pub struct Volume {
     pub price_iops_per_month: f32,
 }
 
-impl Resource for Volume {
+impl ResourceTrait for Volume {
     fn compute(&mut self) -> Result<(), ResourceError> {
         let mut price_per_month = 0_f32;
         price_per_month += self.volume_size.unwrap() as f32 * self.price_gb_per_month;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     if let Some(input_file) = args.input.as_deref() {
         let f = File::open(input_file).expect("Error while opening the file");
         let reader = BufReader::new(f);
-        let stream = Deserializer::from_reader(reader).into_iter::<core::ResourceType>();
+        let stream = Deserializer::from_reader(reader).into_iter::<core::Resource>();
         resources = core::Resources {
             resources: Vec::new(),
         };

--- a/src/oapi.rs
+++ b/src/oapi.rs
@@ -449,7 +449,7 @@ impl Input {
                 price_product_per_cpu_per_hour: specs.price_product_per_cpu_per_hour,
                 price_product_per_vm_per_hour: specs.price_product_per_vm_per_hour,
             };
-            resources.resources.push(core::ResourceType::Vm(core_vm));
+            resources.resources.push(core::Resource::Vm(core_vm));
         }
     }
 
@@ -475,7 +475,7 @@ impl Input {
             };
             resources
                 .resources
-                .push(core::ResourceType::Volume(core_volume));
+                .push(core::Resource::Volume(core_volume));
         }
     }
 }


### PR DESCRIPTION
With this PR, we can read the json output without making request to the API. Here some info:
1) the enum is as follow
```rust
pub enum Resource {
    Vm(Vm),
    Volume(Volume),
}
```
Because, we need to encapsulate the object to be able to implement the trait `ResourceTrait` (see [stackoverflow](https://stackoverflow.com/a/71541115/8867266))

This is the only solution found to be able to call easily (without reimplementing the trait for the enum) ResourceTrait `trait` method and to call them we can use pattern matching like that
```rust
match resource {
    Resource::Volume(volume) => volume.compute()?,
    Resource::Vm(vm) => vm.compute()?,
}
```

2) With this encapsulation and ```#[serde(tag = "resource_type")]```, `resource_type` will always be set  according to the type (`Vm`, `Volume`) therefore it is not anymore necessary to have it directly in each variant struct




Closes #8 