### PR TITLE
Add Windows target to the release

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,19 @@ jobs:
               - name: Linux x86_64
                 os: ubuntu-latest
                 target: x86_64-unknown-linux-musl
+                suffix: ''
               - name: macOS x86_64
                 os: macos-latest
                 target: x86_64-apple-darwin
+                suffix: ''
               - name: macOS M1
                 os: macos-latest
                 target: aarch64-apple-darwin
+                suffix: ''
+              - name: Windows
+                os: windows-latest
+                target: x86_64-pc-windows-msvc
+                suffix: .exe
     runs-on: ${{ matrix.os }}
     name: Create artefact for ${{ matrix.name }}
     needs: [release]
@@ -57,7 +64,7 @@ jobs:
       - name: Build
         run: cargo build --target ${{ matrix.target }} --release
       - name: Move binary
-        run: mv target/${{ matrix.target }}/release/osc-cost osc-cost-${{ github.ref_name }}-${{ matrix.target }}
+        run: mv target/${{ matrix.target }}/release/osc-cost${{ matrix.suffix }} osc-cost-${{ github.ref_name }}-${{ matrix.target }}${{ matrix.suffix }}
       - name: Upload Artefact to release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -66,4 +73,4 @@ jobs:
           name: Release ${{ github.ref_name }}
           draft: true
           prerelease: false
-          files: osc-cost-${{ github.ref_name }}-${{ matrix.target }}
+          files: osc-cost-${{ github.ref_name }}-${{ matrix.target }}${{ matrix.suffix }}

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,6 +7,6 @@ Files: *.md
 Copyright: 2022 Outscale SAS <support@outscale.com>
 License: CC-BY-4.0
 
-Files: version Makefile sdk_version api_version *.rs .git* src/* *.yml *.yaml .patch/*.patch *.patch Cargo.toml Cargo.lock examples/config_example.json int-tests/*
+Files: version Makefile sdk_version api_version *.rs .git* src/* *.yml *.yaml .patch/*.patch *.patch Cargo.toml Cargo.lock examples/config_example.json int-tests/* .cargo/config
 Copyright: 2022 Outscale SAS <support@outscale.com>
 License: BSD-3-Clause


### PR DESCRIPTION
MSVC ABI is the default target of windows

It is statically linked so that the user does not have to install `VCRUNTIME140.dll`(see [stackoverflow](https://stackoverflow.com/questions/31770604/how-to-generate-statically-linked-executables/44387312#44387312))

See https://github.com/outscale-mdr/osc-cost/releases/tag/v0.2.2

Closes #76 