### PR TITLE
Remove csv format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,18 +598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,28 +938,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1968,7 +1934,6 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
- "csv",
  "env_logger",
  "http 0.1.21",
  "icu_locid",
@@ -2403,12 +2368,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ readme = "docs/README.md"
 [dependencies]
 chrono = "0.4.22"
 clap = { version = "4.0.18", features = ["derive"] }
-csv = "1.1.6"
 env_logger = "0.9.3"
 http = "0.1.21"
 lazy_static = "1.4.0"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Some events may trigger a major (breaking) version like option deprecation or ma
 osc-cost's code is organized in order to have:
 - a choosen input (Outscale API, json, ...)
 - a core which compute costs
-- a choosen output format (hour, month, csv, json, ...)
+- a choosen output format (hour, month, json, ...)
 
 # Debuging
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,6 @@ Read license for more details.
   - Current cost per hour
   - Current cost per month
   - Json (line-delimited JSON document)
-  - CSV
   - Human
 
 🚨 Warning: snapshot computation is currently known to be over-priced.
@@ -95,13 +94,6 @@ osc-cost --format=hour
 ```
 osc-cost --format=month
 150.91
-```
-
-```
-osc-cost --format=csv
-resource_type,osc_cost_version,account_id,read_date_rfc3339,region,resource_id,price_per_hour,price_per_month,vm_type,vm_vcpu_gen,vm_core_performance,vm_image,vm_vcpu,vm_ram_gb,price_vcpu_per_hour,price_ram_gb_per_hour,price_box_per_hour,price_product_per_ram_gb_per_hour,price_product_per_cpu_per_hour,price_product_per_vm_per_hour
-Vm,0.1.0,509075394552,2022-11-24T11:14:31.605623096+00:00,eu-west-2,i-682fc9e7,0.044999998,32.85,tinav5.c1r1p1,5,highest,ami-bb490c7e,1,1,0.04,0.005,0.0,0.0,0.0,0.0
-...
 ```
 
 ```

--- a/int-tests/run.sh
+++ b/int-tests/run.sh
@@ -76,53 +76,42 @@ ko_or_die "bad arg" "$oc" --bla
 ok_or_die "write json output" "$oc" --format json --output output.json
 ok_or_die "write hour output" "$oc" --format hour --output output.hour
 ok_or_die "write month output" "$oc" --format month --output output.month
-ok_or_die "write csv output" "$oc" --format csv --output output.csv
 
 # format test with api input source
 ok_or_die "json format with implicit api input source" "$oc" --format json
 ok_or_die "hour format with implicit api input source" "$oc" --format hour
 ok_or_die "month format with implicit api input source" "$oc" --format month
-ok_or_die "csv format with implicit api input source" "$oc" --format csv
 
 ok_or_die "json format with explicit api input source" "$oc" --source api --format json
 ok_or_die "hour format with explicit api input source" "$oc" --source api --format hour
 ok_or_die "month format with explicit api input source" "$oc" --source api --format month
-ok_or_die "csv format with explicit api input source" "$oc" --source api --format csv
 
 ok_or_die "aggregate json format with implicit api input source" "$oc" --aggregate --format json
 ko_or_die "aggregate hour format with implicit api input source" "$oc" --aggregate --format hour
 ko_or_die "aggregate month format with implicit api input source" "$oc" --aggregate --format month
-ok_or_die "aggregate csv format with implicit api input source" "$oc" --aggregate --format csv
 
 ok_or_die "aggregate json format with explicit api input source" "$oc" --aggregate --source api --format json
 ko_or_die "aggregate hour format with explicit api input source" "$oc" --aggregate --source api --format hour
 ko_or_die "aggregate month format with explicit api input source" "$oc" --aggregate --source api --format month
-ok_or_die "aggregate csv format with explicit api input source" "$oc" --aggregate --source api --format csv
 
 # format test with json input source
 ok_or_die "json format with implicit json input source" "$oc" --input output.json --format json
 ok_or_die "hour format with implicit json input source" "$oc" --input output.json --format hour
 ok_or_die "month format with implicit json input source" "$oc" --input output.json --format month
-ok_or_die "csv format with implicit json input source" "$oc" --input output.json --format csv
 
 ok_or_die "json format with explicit json input source" "$oc" --input output.json --source json --format json
 ok_or_die "hour format with explicit json input source" "$oc" --input output.json --source json --format hour
 ok_or_die "month format with explicit json input source" "$oc" --input output.json --source json --format month
-ok_or_die "csv format with explicit json input source" "$oc" --input output.json --source json --format csv
 
 ok_or_die "aggregate json format with implicit json input source" "$oc" --aggregate --input output.json --format json
 ko_or_die "aggregate hour format with implicit json input source" "$oc" --aggregate --input output.json --format hour
 ko_or_die "aggregate month format with implicit json input source" "$oc" --aggregate --input output.json --format month
-ok_or_die "aggregate csv format with implicit json input source" "$oc" --aggregate --input output.json --format csv
 
 ok_or_die "aggregate json format with explicit json input source" "$oc" --aggregate --input output.json --source json --format json
 ko_or_die "aggregate hour format with explicit json input source" "$oc" --aggregate --input output.json --source json --format hour
 ko_or_die "aggregate month format with explicit json input source" "$oc" --aggregate --input output.json --source json --format month
-ok_or_die "aggregate csv format with explicit json input source" "$oc" --aggregate --input output.json --source json --format csv
 
 # input should only work with json as input source
-echo "some,non-empty,csv" > output.csv
-ko_or_die "input as csv should be an error" "$oc" --input output.csv
 ko_or_die "input as hour should be an error" "$oc" --input output.hour
 ko_or_die "input as month should be an error" "$oc" --input output.month
 ko_or_die "--input with --source api" "$oc" --input somefile --source api

--- a/src/args.rs
+++ b/src/args.rs
@@ -49,7 +49,6 @@ pub enum OutputFormat {
     Month,
     Year,
     Json,
-    Csv,
     Ods,
     Human,
     Prometheus,
@@ -75,7 +74,6 @@ impl Args {
             (false, _) => 0,
             (true, OutputFormat::Json) => 0,
             (true, OutputFormat::Human) => 0,
-            (true, OutputFormat::Csv) => 0,
             (true, OutputFormat::Ods) => 0,
             (true, OutputFormat::Prometheus) => 0,
             (true, OutputFormat::Hour) => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -169,15 +169,6 @@ impl Resources {
         Ok(out)
     }
 
-    pub fn csv(&self) -> Result<String, Box<dyn error::Error>> {
-        let mut csv_writer = csv::WriterBuilder::new().flexible(true).from_writer(vec![]);
-        for resource in &self.resources {
-            csv_writer.serialize(resource)?;
-        }
-        let output = String::from_utf8(csv_writer.into_inner()?)?;
-        Ok(output)
-    }
-
     pub fn ods(&self) -> crate::ods::error::Result<Vec<u8>> {
         to_bytes(&self.resources)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             OutputFormat::Month => format!("{}", resources.cost_per_month()?).into_bytes(),
             OutputFormat::Year => format!("{}", resources.cost_per_year()?).into_bytes(),
             OutputFormat::Json => resources.json()?.into_bytes(),
-            OutputFormat::Csv => resources.csv()?.into_bytes(),
             OutputFormat::Prometheus => (resources.prometheus()?).into_bytes(),
             OutputFormat::Ods => resources.ods()?,
             OutputFormat::Human => resources.aggregate().human()?.into_bytes(),


### PR DESCRIPTION
After experimenting the CSV format and developping the ODS format, we've decided to remove the CSV format because it does not provide additional feature

Closes #40 