### PR TITLE
Use region instead of region_name

### DIFF
--- a/helm/entrypoint.sh
+++ b/helm/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$2" ]]; then
     echo "$2 not found" >&2
     exit 1
 fi
-jq -n '{default: {"access_key": "$OSC_ACCESS_KEY", "secret_key": "$OSC_SECRET_KEY", "host": "outscale.com", "https": true, "method": "POST", "region_name": "$OSC_REGION"}}' > $4
+jq -n '{default: {"access_key": "$OSC_ACCESS_KEY", "secret_key": "$OSC_SECRET_KEY", "host": "outscale.com", "https": true, "method": "POST", "region": "$OSC_REGION"}}' > $4
 while true;
   do 
     echo -e "HTTP/1.1 200 OK\n\n$($2 $3)" \


### PR DESCRIPTION
We should use region instead of region_name.

It work before because it will use the default region eu-west-2

Closes #98 