### PR TITLE
Set new release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "osc-cost"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osc-cost"
-version = "0.2.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["OpenSource Team <opensource@outscale.com>"]
 license = "BSD-3-Clause"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,6 +30,6 @@ Gitub bot should have produced a new version and creating the new release tag sh
 If this is not the case:
 1. Be sure have the latest version from repository.
 2. `make test` and fix any issue.
-3. Update Cargo.toml with new version following [semantic versioning](https://semver.org/) and commit
+3. Update Cargo.toml and Cargo.lock with new version following [semantic versioning](https://semver.org/) and commit
 4. PR, review and merge
 5. Create new release


### PR DESCRIPTION
To have the same version as the new release (v0.3.1) for the binary and to be able to publish it.