### PR TITLE
[helm] Fix for param name and probes

### DIFF
--- a/helm/entrypoint.sh
+++ b/helm/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$3" ]]; then
     echo "$3 not found" >&2
     exit 1
 fi
-jq -n '{default: {"access_key": "$OSC_ACCESS_KEY", "secret_key": "$OSC_SECRET_KEY", "host": "outscale.com", "https": true, "method": "POST", "region": "$OSC_REGION"}}' > $4
+jq -n '{default: {"access_key": "$OSC_ACCESS_KEY", "secret_key": "$OSC_SECRET_KEY", "host": "outscale.com", "https": true, "method": "POST", "region": "$OSC_REGION"}}' > $2
 while true;
   do 
     echo -e "HTTP/1.1 200 OK\n\n$($3 $4 $OSCCOST_EXTRA_PARAMS)" \

--- a/helm/osccost/templates/deployment.yaml
+++ b/helm/osccost/templates/deployment.yaml
@@ -54,22 +54,6 @@ spec:
             - name: http-metrics
               containerPort: 8080
               protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: 8080
-            initialDelaySeconds: 15
-            timeoutSeconds: 1
-            periodSeconds: 20
-            successThreshold: 1
-            failureThreshold: 3
-          readinessProbe:
-            tcpSocket:
-              port: 8080
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
         {{- if .containers.resources }}
           resources:
             requests:

--- a/helm/osccost/templates/deployment.yaml
+++ b/helm/osccost/templates/deployment.yaml
@@ -55,25 +55,21 @@ spec:
               containerPort: 8080
               protocol: TCP
           livenessProbe:
-            initialDelaySeconds: 30
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
             periodSeconds: 20
             successThreshold: 1
-            failureThreshold: 10
-            timeoutSeconds: 10
-            httpGet:
-              path: /metrics
-              port: 8080
-              scheme: HTTP
+            failureThreshold: 3
           readinessProbe:
-            initialDelaySeconds: 30
-            periodSeconds: 20
-            successThreshold: 1
-            failureThreshold: 10
-            timeoutSeconds: 10
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: 8080
-              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
         {{- if .containers.resources }}
           resources:
             requests:


### PR DESCRIPTION
Hello,
I have made an error in the previous merge request, sorry for that.

The idea to pull /metrics to perform the readiness and liveness probes was a terrible idea, it totally overload the api calls (especially if you did not disable oos count)
So, I remove it.
Docker need to be rebuilt by the way, should I update release version also ?
