### PR TITLE
Relabeling metrics

### DIFF
--- a/helm/osccost/templates/servicemonitor.yaml
+++ b/helm/osccost/templates/servicemonitor.yaml
@@ -18,6 +18,14 @@ spec:
     - honorLabels: true
       targetPort: http-metrics
       interval: {{ .interval }}
+{{- if .Values.osccost.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ tpl (toYaml .Values.osccost.serviceMonitor.metricRelabelings | indent 8) . }}
+{{- end }}
+{{- if .Values.osccost.serviceMonitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.osccost.serviceMonitor.relabelings | indent 8 }}
+{{- end }}
   namespaceSelector:
     matchNames:
       - {{ $root.Release.Namespace }}

--- a/helm/osccost/templates/servicemonitor.yaml
+++ b/helm/osccost/templates/servicemonitor.yaml
@@ -18,13 +18,13 @@ spec:
     - honorLabels: true
       targetPort: http-metrics
       interval: {{ .interval }}
-{{- if .Values.osccost.serviceMonitor.metricRelabelings }}
+{{- if .metricRelabelings }}
       metricRelabelings:
-{{ tpl (toYaml .Values.osccost.serviceMonitor.metricRelabelings | indent 8) . }}
+{{ tpl (toYaml .metricRelabelings | indent 8) . }}
 {{- end }}
-{{- if .Values.osccost.serviceMonitor.relabelings }}
+{{- if .relabelings }}
       relabelings:
-{{ toYaml .Values.osccost.serviceMonitor.relabelings | indent 8 }}
+{{ toYaml .relabelings | indent 8 }}
 {{- end }}
   namespaceSelector:
     matchNames:

--- a/helm/osccost/values.yaml
+++ b/helm/osccost/values.yaml
@@ -6,7 +6,24 @@ osccost:
     # -- enable serviceMonitor 
     enable: True 
     # -- scrape interval
-    interval: 10m   
+    interval: 10m
+    ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ##
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+    ## RelabelConfigs to apply to samples before scraping
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ##
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
   serviceAccount:
     # -- enable serviceAccount
     enable: True


### PR DESCRIPTION
This small update allow to deploy multiple instance and specify the account or any label you want for example:

```bash
helm upgrade --install osccost osccost \
  --repo git+https://github.com/outscale/osc-cost@helm/osccost?ref=v0.3.3 \
  --namespace osccost \
  --create-namespace \
  --set osccost.serviceMonitor.relabelings[0].targetLabel=account \
  --set osccost.serviceMonitor.relabelings[0].replacement=my-production \
  --set osccost.secret.oscAccessKey=xxxxxxxxxxxxxxxxxxxx \
  --set osccost.secret.oscSecretKey=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
  --set osccost.secret.oscRegion=cloudgouv-eu-west-1 \
  --set osccost.ingress.enable=false \
  --set osccost.deployment.containers.resources.cpu.limits=1 \
  --set osccost.deployment.containers.resources.memory.limits=2Gi \
  --set osccost.deployment.containers.pullPolicy=IfNotPresent \
  --set osccost.deployment.containers.osccostExtraParams='--skip-resource Oos'
```