### PR TITLE
Rework the profile loading

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -34,8 +34,8 @@ pub struct Drift {
 #[command(author, version, about, long_about=None)]
 pub struct Args {
     // Profile name to use in ~/.osc/config.json
-    #[arg(long, short = 'p', default_value_t = String::from("default"))]
-    pub profile: String,
+    #[arg(long, short = 'p')]
+    pub profile: Option<String>,
     #[arg(value_enum, long)]
     pub source: Option<InputSource>,
     #[arg(value_enum, long, default_value_t = OutputFormat::Human)]

--- a/src/oapi.rs
+++ b/src/oapi.rs
@@ -328,7 +328,7 @@ impl Input {
             }
             break response?;
         };
-        info!("{:#?}", result);
+        debug!("{:#?}", result);
 
         let subregions = match result.subregions {
             None => {


### PR DESCRIPTION
Before this PR, we always use environment variable credentials to setup the SDK and then the profile set in the paramater. However, this does not follow Outscale OpenSource standard which is:
- use paramater value
- use environment variable
- use default value