### PR TITLE
Prometheus 3.x support and small fixes

### DIFF
--- a/helm/entrypoint.sh
+++ b/helm/entrypoint.sh
@@ -21,6 +21,6 @@ fi
 jq -n '{default: {"access_key": "$OSC_ACCESS_KEY", "secret_key": "$OSC_SECRET_KEY", "host": "outscale.com", "https": true, "method": "POST", "region": "$OSC_REGION"}}' > $2
 while true;
   do 
-    echo -e "HTTP/1.1 200 OK\n\n$($3 $4 $OSCCOST_EXTRA_PARAMS)" \
+    echo -e "HTTP/1.1 200 OK\nContent-Type: text/plain; version=0.0.4; charset=utf-8\n\n$($3 $4 $OSCCOST_EXTRA_PARAMS)" \
   | nc -l -k -p $1 -q 1;
 done

--- a/helm/osccost/templates/deployment.yaml
+++ b/helm/osccost/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/version: "{{ $root.Chart.Version }}"
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: {{ .repliaccount | default "1" }}
+  replicas: {{ .replicas | default "1" }}
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ $root.Release.Name }}"
@@ -72,7 +72,9 @@ spec:
             {{ $key }}: {{ $val }}
           {{- end }}
         {{- end }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .imagePullSecrets | default "regcred" }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/osccost/templates/service.yaml
+++ b/helm/osccost/templates/service.yaml
@@ -15,8 +15,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: http-metrics
+    - name: http-metrics
+      port: 8080
+      targetPort: 8080
       protocol: TCP
   selector:
     app.kubernetes.io/name: "{{ $root.Release.Name }}"

--- a/helm/osccost/templates/servicemonitor.yaml
+++ b/helm/osccost/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   endpoints:
     - honorLabels: true
-      targetPort: http-metrics
+      port: http-metrics
       interval: {{ .interval }}
 {{- if .metricRelabelings }}
       metricRelabelings:

--- a/helm/osccost/values.yaml
+++ b/helm/osccost/values.yaml
@@ -1,10 +1,11 @@
 osccost:
+  replicas: 1
   service:
     # -- enable service
     enable: True
   serviceMonitor:
-    # -- enable serviceMonitor 
-    enable: True 
+    # -- enable serviceMonitor
+    enable: True
     # -- scrape interval
     interval: 10m
     # -- MetricRelabelConfigs to apply to samples after scraping, but before ingestion


### PR DESCRIPTION
With the new prometheus 3.x release, if we don't add a header that contains at least `Content-Type: text/plain; version=0.0.4` you have the following error:
```bash
Error scraping target: non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target
```
See prometheus issue [here](https://github.com/prometheus/prometheus/issues/15485).

So I have added this header in entrypoint.sh file.

I have also cleaned a non used value that contains a typo `repliaccount`, now simply named `replicas`.
I have also removed default value for imagePullSecrets that output error in Kubernetes Event log due to non existing Secret (done already [here](https://github.com/outscale/osc-bsu-csi-driver/pull/815) for example).
Latest small update is about Service, Deployment and ServiceMonitor and their targetPort, port and name.
Now everything is identical.