### PR TITLE
Add missing /metrics route

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -46,6 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let app = Router::new()
         .route("/", get(root))
+        .route("/metrics", get(root))
         .route("/health", get(healhcheck))
         .with_state(state);
 


### PR DESCRIPTION
# 📦 Pull Request Template

## Description
When used as a prometheus exporter, current servicemonitor.yaml file does not include a path parameter [here](https://github.com/outscale/osc-cost/blob/main/helm/osccost/templates/servicemonitor.yaml#L17-L20)

So, we need to manually fix it.
But the real issue is to not answer to a default /metrics.
This small pr does it.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet
