### PR TITLE
Allow to pass extra params and support at leat need-default-resource

### DIFF
--- a/helm/osccost/templates/deployment.yaml
+++ b/helm/osccost/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         - name: osc-cost
           image: "{{ .containers.image }}:{{ .containers.imageTag }}"
           imagePullPolicy: {{ .containers.pullPolicy }}
+          {{- if .containers.osccostExtraParams }}
+          args:
+            {{- toYaml .containers.osccostExtraParams | nindent 12 }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /health
@@ -54,10 +58,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "osccost.secret" $root }}
                   key: OSC_REGION
-            {{- if .containers.osccostExtraParams }}
-            - name: OSCCOST_EXTRA_PARAMS
-              value: "{{ .containers.osccostExtraParams }}"
-            {{- end }}
           ports:
             - name: http-metrics
               containerPort: 8080

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,12 +21,15 @@ struct Args {
     pub profile: Option<String>,
     #[arg(long, short = 'a', default_value_t = false)]
     pub aggregate: bool,
+    #[arg(long, short = 'n', default_value_t = false)]
+    pub need_default_resource: bool,
 }
 
 #[derive(Clone)]
 struct AppState {
     input: Arc<Mutex<Input>>,
     aggregate: bool,
+    need_default_resource: bool,
 }
 
 #[tokio::main]
@@ -42,6 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = AppState {
         input: Arc::new(Mutex::new(input)),
         aggregate: args.aggregate,
+        need_default_resource: args.need_default_resource,
     };
 
     let app = Router::new()
@@ -60,10 +64,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn root(State(state): State<AppState>) -> Result<Response, String> {
     let local_lock = state.input.clone();
+    let need_default_resource = state.need_default_resource;
     let mut resources = match tokio::task::spawn_blocking(move || {
         let mut inputs = local_lock
             .lock()
             .map_err(|e| format!("Could not lock mutex: {e}"))?;
+        inputs.need_default_resource = need_default_resource;
         inputs
             .fetch()
             .map_err(|e| format!("Could not fetch inputs: {e}"))?;


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

Hello,
since the add of the dedicated exporter endpoint, the parameter `need-default-resource` has been lost.
It's really mandatory with prometheus metrics to have everytime all the metrics available.

Fixes: #163

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet
